### PR TITLE
removed engine combobox in container information tab

### DIFF
--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/containers/ContainersController.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/containers/ContainersController.java
@@ -29,11 +29,8 @@ import org.phoenicis.javafx.views.common.ErrorMessage;
 import org.phoenicis.javafx.views.mainwindow.containers.ContainerPanelFactory;
 import org.phoenicis.javafx.views.mainwindow.containers.ViewContainers;
 import org.phoenicis.javafx.views.mainwindow.containers.WinePrefixContainerPanel;
-import org.phoenicis.repository.dto.CategoryDTO;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
+import java.util.ArrayList;
 
 import static org.phoenicis.configuration.localisation.Localisation.tr;
 
@@ -60,30 +57,34 @@ public class ContainersController {
         });
 
         viewContainers.setOnSelectContainer((ContainerDTO containerDTO) -> {
-            List<CategoryDTO> categoryDTOS = Collections
-                    .singletonList(new CategoryDTO.Builder().withName("Wine").build());
-            enginesSource.fetchAvailableEngines(categoryDTOS, engineCategoryDTOS -> {
-                final WinePrefixContainerPanel panel = winePrefixContainerPanelFactory.createContainerPanel(
-                        (WinePrefixContainerDTO) containerDTO, viewContainers.getThemeManager(),
-                        engineCategoryDTOS.stream().flatMap(category -> category.getSubCategories().stream())
-                                .flatMap(subCategory -> subCategory.getPackages().stream())
-                                .collect(Collectors.toList()),
-                        winePrefixContainerController);
+            // disabled fetching of available engines
+            // changing engine does not work currently
+            // querying Wine webservice causes performance issues on systems with slow internet connection
+            // List<CategoryDTO> categoryDTOS = Collections.singletonList(new CategoryDTO.Builder().withName("Wine").build());
+            // enginesSource.fetchAvailableEngines(categoryDTOS, engineCategoryDTOS -> {
+            final WinePrefixContainerPanel panel = winePrefixContainerPanelFactory.createContainerPanel(
+                    (WinePrefixContainerDTO) containerDTO,
+                    viewContainers.getThemeManager(),
+                    new ArrayList<>(),
+                    /*engineCategoryDTOS.stream().flatMap(category -> category.getSubCategories().stream())
+                    .flatMap(subCategory -> subCategory.getPackages().stream())
+                    .collect(Collectors.toList()),*/
+                    winePrefixContainerController);
 
-                panel.setOnDeletePrefix(winePrefixDTO -> {
-                    new ConfirmMessage(tr("Delete {0} container", winePrefixDTO.getName()),
-                            tr("Are you sure you want to delete the {0} container?", winePrefixDTO.getName()))
-                                    .ask(() -> {
-                                        winePrefixContainerController.deletePrefix(winePrefixDTO,
-                                                e -> Platform.runLater(() -> new ErrorMessage("Error", e).show()));
-                                        loadContainers();
-                                    });
-                });
-
-                panel.setOnClose(viewContainers::closeDetailsView);
-
-                Platform.runLater(() -> viewContainers.showDetailsView(panel));
+            panel.setOnDeletePrefix(winePrefixDTO -> {
+                new ConfirmMessage(tr("Delete {0} container", winePrefixDTO.getName()),
+                        tr("Are you sure you want to delete the {0} container?", winePrefixDTO.getName()))
+                                .ask(() -> {
+                                    winePrefixContainerController.deletePrefix(winePrefixDTO,
+                                            e -> Platform.runLater(() -> new ErrorMessage("Error", e).show()));
+                                    loadContainers();
+                                });
             });
+
+            panel.setOnClose(viewContainers::closeDetailsView);
+
+            Platform.runLater(() -> viewContainers.showDetailsView(panel));
+            //});
         });
     }
 

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/containers/WinePrefixContainerInformationTab.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/containers/WinePrefixContainerInformationTab.java
@@ -1,8 +1,6 @@
 package org.phoenicis.javafx.views.mainwindow.containers;
 
-import javafx.collections.FXCollections;
 import javafx.scene.control.Button;
-import javafx.scene.control.ComboBox;
 import javafx.scene.control.Label;
 import javafx.scene.control.Tab;
 import javafx.scene.layout.GridPane;
@@ -10,7 +8,6 @@ import javafx.scene.layout.Priority;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
 import javafx.scene.text.Text;
-import javafx.util.StringConverter;
 import org.phoenicis.containers.dto.WinePrefixContainerDTO;
 import org.phoenicis.engines.dto.EngineVersionDTO;
 import org.phoenicis.javafx.views.common.TextWithStyle;
@@ -90,14 +87,16 @@ public class WinePrefixContainerInformationTab extends Tab {
         spacer.setPrefHeight(20);
         VBox.setVgrow(spacer, Priority.NEVER);
 
-        ComboBox<EngineVersionDTO> changeEngineComboBox = new ComboBox<EngineVersionDTO>(
+        // changing engine does not work currently
+        // disabled combobox to avoid confusion of users
+        /*ComboBox<EngineVersionDTO> changeEngineComboBox = new ComboBox<EngineVersionDTO>(
                 FXCollections.observableList(engineVersions));
         changeEngineComboBox.setConverter(new StringConverter<EngineVersionDTO>() {
             @Override
             public String toString(EngineVersionDTO object) {
                 return object.getVersion();
             }
-
+        
             @Override
             public EngineVersionDTO fromString(String string) {
                 return engineVersions.stream().filter(engineVersion -> engineVersion.getVersion().equals(string))
@@ -105,12 +104,12 @@ public class WinePrefixContainerInformationTab extends Tab {
             }
         });
         changeEngineComboBox.getSelectionModel().select(engineVersions.stream()
-                .filter(engineVersion -> engineVersion.getVersion().equals(container.getVersion())).findFirst().get());
+                .filter(engineVersion -> engineVersion.getVersion().equals(container.getVersion())).findFirst().get());*/
 
         Button deleteButton = new Button(tr("Delete container"));
         deleteButton.setOnMouseClicked(event -> this.onDeletePrefix.accept(container));
 
-        informationPane.getChildren().addAll(informationContentPane, spacer, changeEngineComboBox, deleteButton);
+        informationPane.getChildren().addAll(informationContentPane, spacer, /*changeEngineComboBox,*/ deleteButton);
         this.setContent(informationPane);
     }
 


### PR DESCRIPTION
Changing the engine version does not work currently, so the combobox suggests functionality which is not there. Moreover, fetching available engines from the Wine webservice causes performance issues on systems with slow Internet connection.

fixes #974