### PR TITLE
split filtered and not filtered resources

### DIFF
--- a/phoenicis-configuration/pom.xml
+++ b/phoenicis-configuration/pom.xml
@@ -98,6 +98,9 @@
         <resources>
             <resource>
                 <directory>src/main/resources</directory>
+            </resource>
+            <resource>
+                <directory>src/main/resources-filtered</directory>
                 <filtering>true</filtering>
             </resource>
         </resources>

--- a/phoenicis-configuration/src/main/java/org/phoenicis/configuration/PhoenicisGlobalConfiguration.java
+++ b/phoenicis-configuration/src/main/java/org/phoenicis/configuration/PhoenicisGlobalConfiguration.java
@@ -25,6 +25,7 @@ import org.springframework.context.annotation.PropertySource;
 import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 
 @Configuration
+@PropertySource("classpath:phoenicis.properties")
 @PropertySource("classpath:${os.name}.properties")
 @PropertySource(value = "file:${application.user.settings}", ignoreResourceNotFound = true)
 public class PhoenicisGlobalConfiguration {

--- a/phoenicis-configuration/src/main/resources-filtered/phoenicis.properties
+++ b/phoenicis-configuration/src/main/resources-filtered/phoenicis.properties
@@ -1,0 +1,21 @@
+#
+# Copyright (C) 2015-2017 PÂRIS Quentin
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+application.version                         =           ${project.version}
+application.gitRevision                     =           ${buildNumber}
+application.buildTimestamp                  =           ${timestamp}

--- a/phoenicis-configuration/src/main/resources/Linux.properties
+++ b/phoenicis-configuration/src/main/resources/Linux.properties
@@ -17,9 +17,6 @@
 #
 
 application.name                            =           PlayOnLinux
-application.version                         =           ${project.version}
-application.gitRevision                     =           ${buildNumber}
-application.buildTimestamp                  =           ${timestamp}
 application.theme                           =           default
 application.scale                           =           12
 application.viewsource                      =           false

--- a/phoenicis-configuration/src/main/resources/Mac OS X.properties
+++ b/phoenicis-configuration/src/main/resources/Mac OS X.properties
@@ -17,9 +17,6 @@
 #
 
 application.name                            =           PlayOnMac
-application.version                         =           ${project.version}
-application.gitRevision                     =           ${buildNumber}
-application.buildTimestamp                  =           ${timestamp}
 application.theme                           =           default
 application.scale                           =           12
 application.viewsource                      =           false


### PR DESCRIPTION
E.g. user.home may not be expanded during build, otherwise it will only be correct for the user who built the application at runtime.

fixes #991