### PR TITLE
set minimum width for icon list

### DIFF
--- a/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/default/main.less
+++ b/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/default/main.less
@@ -178,6 +178,7 @@
 /************************ right ************************/
 /*******************************************************/
 .rightPane {
+  -fx-min-width: 15em;
   -fx-pref-width: 55em;
   -fx-border-width: 0;
   -fx-border-style: none;
@@ -286,6 +287,7 @@
 /********************** miniature **********************/
 /*******************************************************/
 .iconListWidget {
+  -fx-min-width: 15em;
   -fx-pref-width: 53.5em;
   -fx-background-color: white;
   -fx-border-width: 0;


### PR DESCRIPTION
The minimum width is chosen such that one miniature is still completely visible.

![minimum width](https://user-images.githubusercontent.com/3973260/29513123-a745baac-8664-11e7-8ebf-ff115d3cb137.png)