### PR TITLE
removed minimum search string length

### DIFF
--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/common/DelayedFilterTextConsumer.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/common/DelayedFilterTextConsumer.java
@@ -32,7 +32,7 @@ public class DelayedFilterTextConsumer implements Consumer<String> {
         this.pause.setOnFinished(event -> {
             String text = filterText.toLowerCase();
 
-            if (text != null && text.length() >= 3) {
+            if (text != null) {
                 internalTextConsumer.accept(text);
             } else {
                 internalTextConsumer.accept("");


### PR DESCRIPTION
The minimum search string length had been implemented to avoid performance problems at a time when every search rebuilt the whole applications list. However, this is not required anymore with the current `FilteredList` solution.

fixes #1037