### PR TITLE
Fixed a bug in the filtered list that appeared when you try to add a new repository

### DIFF
--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/common/PhoenicisFilteredList.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/common/PhoenicisFilteredList.java
@@ -158,7 +158,7 @@ public class PhoenicisFilteredList<E> extends TransformationList<E, E> {
             int internalIndex = getIndexToSourceIndex(index);
 
             if (filtered.remove(index)) {
-                nextRemove(internalIndex, getSource().get(index));
+                nextRemove(internalIndex, c.getRemoved().get(index - from));
             }
         }
 

--- a/phoenicis-javafx/src/test/java/org/phoenicis/javafx/views/common/PhoenicisFilteredListTest.java
+++ b/phoenicis-javafx/src/test/java/org/phoenicis/javafx/views/common/PhoenicisFilteredListTest.java
@@ -107,6 +107,20 @@ public class PhoenicisFilteredListTest {
         assertEquals(2, (int)filteredList.get(1));
     }
 
+    @Test
+    public void testClear() {
+        ObservableList<Integer> observableList = FXCollections.observableArrayList(Arrays.asList(1, 2, 4, 3));
+        PhoenicisFilteredList<Integer> filteredList = new PhoenicisFilteredList<>(observableList, i -> i % 2 == 0);
+
+        assertEquals(2, filteredList.size());
+        assertEquals(2, (int)filteredList.get(0));
+        assertEquals(4, (int)filteredList.get(1));
+
+        observableList.clear();
+
+        assertEquals(0, filteredList.size());
+    }
+
     private int moduloResult = 0;
 
     @Test


### PR DESCRIPTION
When trying to add a local repository I got an exception.
This PR should fix this.
My guess is, that the `setAll` method of the observable list cleared the source observable list, before the event was triggered for the filtered list. This resulted in "bad" calls to `getSource().get(index)`.