### PR TITLE
Unity theme: removed border of search clean button

### DIFF
--- a/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/unity/main.less
+++ b/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/unity/main.less
@@ -301,7 +301,7 @@
         -fx-text-fill: @text-color;
         -fx-border-radius: 0;
         -fx-background-radius: 0;
-        -fx-label-padding: 0 0 0 3.03em;;
+        -fx-label-padding: 0 0 0 3.03em;
         -fx-background-position: 0.83em 0.1em;
 
         &:hover {
@@ -336,7 +336,9 @@
             -fx-border-color: @focus-color;
             -fx-text-fill: @text-color;
         }
+    }
 
+    .searchBox {
         .searchCleanButton {
             -fx-border-color: transparent;
         }


### PR DESCRIPTION
before:
![before](https://user-images.githubusercontent.com/3973260/29709808-24ef708e-898e-11e7-91f9-57fe2362af02.png)

now:
![now](https://user-images.githubusercontent.com/3973260/29709817-298e75c2-898e-11e7-8275-b61e5b8c4147.png)

