### PR TITLE
fixed width of details view

### DIFF
--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/apps/ViewApps.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/apps/ViewApps.java
@@ -144,6 +144,7 @@ public class ViewApps extends MainWindowView<ApplicationSidebar> {
         appPanel.setOnScriptInstall(this::installScript);
         appPanel.setOnClose(this::closeDetailsView);
         appPanel.setMaxWidth(400);
+        appPanel.prefWidthProperty().bind(this.getTabPane().widthProperty().divide(3));
         this.showDetailsView(appPanel);
     }
 

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/library/ViewLibrary.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/library/ViewLibrary.java
@@ -184,9 +184,10 @@ public class ViewLibrary extends MainWindowView<LibrarySidebar> {
     }
 
     private void showShortcutDetails(ShortcutDTO shortcutDTO) {
-        libraryPanel.setOnClose(this::closeDetailsView);
-        libraryPanel.setShortcutDTO(shortcutDTO);
-        libraryPanel.setMaxWidth(400);
+        this.libraryPanel.setOnClose(this::closeDetailsView);
+        this.libraryPanel.setShortcutDTO(shortcutDTO);
+        this.libraryPanel.setMaxWidth(400);
+        this.libraryPanel.prefWidthProperty().bind(this.getTabPane().widthProperty().divide(3));
         this.showDetailsView(libraryPanel);
     }
 
@@ -198,6 +199,7 @@ public class ViewLibrary extends MainWindowView<LibrarySidebar> {
         this.editShortcutPanel.setOnClose(this::closeDetailsView);
         this.editShortcutPanel.setShortcutDTO(shortcutDTO);
         this.editShortcutPanel.setMaxWidth(400);
+        this.editShortcutPanel.prefWidthProperty().bind(this.getTabPane().widthProperty().divide(3));
         this.showDetailsView(this.editShortcutPanel);
     }
 


### PR DESCRIPTION
Use a preferred width of 1/3 of the window width (3 columns: sidebar, content, details). If the window is too small, the text will still be unreadable because minimum size of sidebar and content push the details view out of the window.

fixes #1053

![details](https://user-images.githubusercontent.com/3973260/29713363-8218624c-899e-11e7-8ea1-b5f476a01487.png)
