### PR TITLE
use same hover/selected colors for all list widgets

### DIFF
--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/common/widgets/lists/compact/CompactListWidget.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/common/widgets/lists/compact/CompactListWidget.java
@@ -43,7 +43,7 @@ public class CompactListWidget<E> extends ListView<CompactListElement<E>> implem
 
         this.setPrefWidth(0);
         this.setPrefHeight(0);
-        this.getStyleClass().add("compactListWidget");
+        this.getStyleClass().addAll("listWidget", "compactListWidget");
         this.setCellFactory(param -> new ListElementListCell<CompactListElement<E>>());
 
         this.items = FXCollections.observableArrayList();

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/common/widgets/lists/details/DetailsListWidget.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/common/widgets/lists/details/DetailsListWidget.java
@@ -43,7 +43,7 @@ public class DetailsListWidget<E> extends ListView<DetailsListElement<E>> implem
 
         this.setPrefWidth(0);
         this.setPrefHeight(0);
-        this.getStyleClass().add("detailsListWidget");
+        this.getStyleClass().addAll("listWidget", "detailsListWidget");
         this.setCellFactory(param -> new ListElementListCell<DetailsListElement<E>>());
 
         this.items = FXCollections.observableArrayList();

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/installations/ViewInstallations.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/installations/ViewInstallations.java
@@ -167,6 +167,7 @@ public class ViewInstallations extends MainWindowView<InstallationsSidebar> {
     public void addInstallation(InstallationDTO installationDTO) {
         populate(new InstallationsUtils().addInstallationToList(this.categories, installationDTO));
         Platform.runLater(() -> {
+            this.activeInstallations.deselectAll();
             this.activeInstallations.select(installationDTO);
             this.showInstallationDetails(installationDTO);
         });

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/installations/ViewInstallations.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/installations/ViewInstallations.java
@@ -167,7 +167,6 @@ public class ViewInstallations extends MainWindowView<InstallationsSidebar> {
     public void addInstallation(InstallationDTO installationDTO) {
         populate(new InstallationsUtils().addInstallationToList(this.categories, installationDTO));
         Platform.runLater(() -> {
-            this.activeInstallations.deselectAll();
             this.activeInstallations.select(installationDTO);
             this.showInstallationDetails(installationDTO);
         });

--- a/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/breezeDark/main.less
+++ b/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/breezeDark/main.less
@@ -361,6 +361,18 @@
 /*******************************************************/
 /********************** miniature **********************/
 /*******************************************************/
+.listWidget {
+    .list-cell {
+        &:hover {
+          -fx-background-color: #284150;
+        }
+
+        &:selected {
+          -fx-background-color: @focus-color;
+        }
+    }
+}
+
 .iconListWidget {
   -fx-background-color: @background-color;
 

--- a/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/breezeDark/main.less
+++ b/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/breezeDark/main.less
@@ -18,6 +18,7 @@
 
 @background-color: #232629;
 @main-color: #31363b;
+@hover-color: #284150;
 @focus-color: #3daee9;
 @text-color: #eff0f1;
 @inactive-text-color: #bdc3c7;
@@ -364,7 +365,7 @@
 .listWidget {
     .list-cell {
         &:hover {
-          -fx-background-color: #284150;
+          -fx-background-color: @hover-color;
         }
 
         &:selected {
@@ -380,7 +381,7 @@
         -fx-background-radius: 0em;
 
         &:hover {
-            -fx-background-color: #284150;
+            -fx-background-color: @hover-color;
         }
 
         &:selected {

--- a/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/default/main.less
+++ b/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/default/main.less
@@ -17,6 +17,8 @@
  */
 
 @background-color: #F0F0F0;
+@hover-color: #EFEFEF;
+@focus-color: #EAEAEA;
 
 /*******************************************************/
 /*********************** general ***********************/
@@ -290,11 +292,11 @@
 .listWidget {
     .list-cell {
         &:hover {
-          -fx-background-color: #EFEFEF;
+          -fx-background-color: @hover-color;
         }
 
         &:selected {
-          -fx-background-color: #EAEAEA;
+          -fx-background-color: @focus-color;
         }
     }
 }
@@ -318,11 +320,11 @@
     -fx-background-radius: 0.8em;
 
     &:hover {
-      -fx-background-color: #EFEFEF;
+      -fx-background-color: @hover-color;
     }
 
     &:selected {
-      -fx-background-color: #EAEAEA;
+      -fx-background-color: @focus-color;
     }
 
     .iconListMiniatureImage {

--- a/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/default/main.less
+++ b/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/default/main.less
@@ -287,6 +287,18 @@
 /*******************************************************/
 /********************** miniature **********************/
 /*******************************************************/
+.listWidget {
+    .list-cell {
+        &:hover {
+          -fx-background-color: #EFEFEF;
+        }
+
+        &:selected {
+          -fx-background-color: #EAEAEA;
+        }
+    }
+}
+
 .iconListWidget {
   -fx-min-width: 15em;
   -fx-pref-width: 53.5em;

--- a/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/unity/main.less
+++ b/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/unity/main.less
@@ -396,6 +396,18 @@
 /*******************************************************/
 /********************** miniature **********************/
 /*******************************************************/
+.listWidget {
+    .list-cell {
+        &:hover {
+            -fx-background-color: rgba(223, 94, 30, 0.7);
+        }
+
+        &:selected {
+            -fx-background-color: rgba(223, 94, 30, 1);
+        }
+    }
+}
+
 .iconListWidget {
     .iconListElement {
         -fx-background-radius: 0.7em;

--- a/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/unity/main.less
+++ b/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/unity/main.less
@@ -18,6 +18,7 @@
 
 @background-color: #f2f1f0;
 @main-color: #e7e5e4;
+@hover-color: rgba(223, 94, 30, 0.7);
 @focus-color: #df5e1e;
 @text-color: #6b6b6a;
 
@@ -399,11 +400,11 @@
 .listWidget {
     .list-cell {
         &:hover {
-            -fx-background-color: rgba(223, 94, 30, 0.7);
+            -fx-background-color: @hover-color;
         }
 
         &:selected {
-            -fx-background-color: rgba(223, 94, 30, 1);
+            -fx-background-color: @focus-color;
         }
     }
 }
@@ -413,11 +414,11 @@
         -fx-background-radius: 0.7em;
 
         &:hover {
-            -fx-background-color: rgba(223, 94, 30, 0.7);
+            -fx-background-color: @hover-color;
         }
 
         &:selected {
-            -fx-background-color: rgba(223, 94, 30, 1);
+            -fx-background-color: @focus-color;
         }
 
         .iconListMiniatureLabel {


### PR DESCRIPTION
fixes #1019 

It's not possible to use the same CSS for the icons list because it's a `ScrollPane` (details list and compact list are `GridPane`).