### PR TITLE
added possibility to configure new shortcut when creating it

### DIFF
--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/library/LibraryController.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/library/LibraryController.java
@@ -28,6 +28,7 @@ import org.phoenicis.library.LibraryManager;
 import org.phoenicis.library.ShortcutManager;
 import org.phoenicis.library.ShortcutRunner;
 import org.phoenicis.library.dto.ShortcutCategoryDTO;
+import org.phoenicis.library.dto.ShortcutCreationDTO;
 import org.phoenicis.library.dto.ShortcutDTO;
 import org.phoenicis.repository.RepositoryManager;
 import org.phoenicis.repository.dto.RepositoryDTO;
@@ -35,7 +36,6 @@ import org.phoenicis.scripts.interpreter.InteractiveScriptSession;
 import org.phoenicis.scripts.interpreter.ScriptInterpreter;
 import org.springframework.beans.factory.annotation.Value;
 
-import java.io.File;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -105,13 +105,13 @@ public class LibraryController {
     }
 
     /**
-     * creates a shortcut for a given executable
-     * @param executable executable file (WineShortcut will search for this file in the given prefix)
+     * creates a new shortcut
+     * @param shortcutCreationDTO DTO describing the new shortcut
      */
-    private void createShortcut(File executable) {
+    private void createShortcut(ShortcutCreationDTO shortcutCreationDTO) {
         // get container
         // TODO: smarter way using container manager
-        final String executablePath = executable.getAbsolutePath();
+        final String executablePath = shortcutCreationDTO.getExecutable().getAbsolutePath();
         final String pathInContainers = executablePath.replace(containersPath, "");
         final String[] split = pathInContainers.split("/");
         final String engineContainer = split[0];
@@ -124,8 +124,12 @@ public class LibraryController {
         interactiveScriptSession.eval("include([\"Engines\", \"" + engine + "\", \"Shortcuts\", \"" + engine + "\"]);",
                 ignored -> interactiveScriptSession.eval("new " + engine + "Shortcut()", output -> {
                     final ScriptObjectMirror shortcutObject = (ScriptObjectMirror) output;
-                    shortcutObject.callMember("name", executable.getName());
-                    shortcutObject.callMember("search", executable.getName());
+                    shortcutObject.callMember("name", shortcutCreationDTO.getName());
+                    shortcutObject.callMember("category", shortcutCreationDTO.getCategory());
+                    shortcutObject.callMember("description", shortcutCreationDTO.getDescription());
+                    ;
+                    shortcutObject.callMember("miniature", shortcutCreationDTO.getMiniature());
+                    shortcutObject.callMember("search", shortcutCreationDTO.getExecutable().getName());
                     shortcutObject.callMember("prefix", container);
                     shortcutObject.callMember("create");
                 }, e -> this.showErrorMessage(e, tr("Error while creating shortcut"))),

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/library/CreateShortcutPanel.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/library/CreateShortcutPanel.java
@@ -74,7 +74,6 @@ final class CreateShortcutPanel extends DetailsView {
         gridPane.add(nameLabel, 0, 0);
 
         TextField name = new TextField();
-        name.getStyleClass().add("input");
         gridPane.add(name, 1, 0);
 
         Tooltip nameErrorTooltip = new Tooltip(tr("Please specify a name!"));
@@ -86,7 +85,6 @@ final class CreateShortcutPanel extends DetailsView {
         gridPane.add(categoryLabel, 0, 1);
 
         TextField category = new TextField();
-        category.getStyleClass().add("input");
         gridPane.add(category, 1, 1);
 
         Tooltip categoryErrorTooltip = new Tooltip(tr("Please specify a category!"));
@@ -98,7 +96,6 @@ final class CreateShortcutPanel extends DetailsView {
         gridPane.add(descriptionLabel, 0, 2);
 
         TextArea description = new TextArea();
-        description.getStyleClass().add("input");
         gridPane.add(description, 1, 2);
 
         // miniature
@@ -108,7 +105,6 @@ final class CreateShortcutPanel extends DetailsView {
         gridPane.add(miniatureLabel, 0, 3);
 
         TextField miniature = new TextField();
-        miniature.getStyleClass().add("input");
 
         Button openMiniatureBrowser = new Button(tr("Choose"));
         openMiniatureBrowser.setOnAction(event -> {
@@ -132,7 +128,6 @@ final class CreateShortcutPanel extends DetailsView {
         gridPane.add(executableLabel, 0, 4);
 
         TextField executable = new TextField();
-        executable.getStyleClass().add("input");
 
         Button openExecutableBrowser = new Button(tr("Choose"));
         openExecutableBrowser.setOnAction(event -> {

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/library/CreateShortcutPanel.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/library/CreateShortcutPanel.java
@@ -156,7 +156,7 @@ final class CreateShortcutPanel extends DetailsView {
             }
             if (StringUtils.isEmpty(category.getText())) {
                 category.pseudoClassStateChanged(errorClass, true);
-                category.setTooltip(nameErrorTooltip);
+                category.setTooltip(categoryErrorTooltip);
                 error = true;
             }
             URI miniatureUri = null;
@@ -168,14 +168,14 @@ final class CreateShortcutPanel extends DetailsView {
                     miniatureUri = miniatureFile.toURI();
                 } else {
                     miniature.pseudoClassStateChanged(errorClass, true);
-                    miniature.setTooltip(nameErrorTooltip);
+                    miniature.setTooltip(miniatureErrorTooltip);
                     error = true;
                 }
             }
             File executableFile = new File(executable.getText());
             if (!executableFile.exists()) {
                 executable.pseudoClassStateChanged(errorClass, true);
-                executable.setTooltip(nameErrorTooltip);
+                executable.setTooltip(executableErrorTooltip);
                 error = true;
             }
             if (!error) {

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/library/CreateShortcutPanel.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/library/CreateShortcutPanel.java
@@ -18,11 +18,9 @@
 
 package org.phoenicis.javafx.views.mainwindow.library;
 
+import javafx.css.PseudoClass;
 import javafx.geometry.VPos;
-import javafx.scene.control.Button;
-import javafx.scene.control.Label;
-import javafx.scene.control.TextArea;
-import javafx.scene.control.TextField;
+import javafx.scene.control.*;
 import javafx.scene.layout.*;
 import javafx.stage.FileChooser;
 import org.apache.commons.lang.StringUtils;
@@ -60,6 +58,7 @@ final class CreateShortcutPanel extends DetailsView {
      * populates the panel
      */
     public void populate() {
+        final PseudoClass errorClass = PseudoClass.getPseudoClass("error");
 
         final VBox vBox = new VBox();
 
@@ -75,7 +74,10 @@ final class CreateShortcutPanel extends DetailsView {
         gridPane.add(nameLabel, 0, 0);
 
         TextField name = new TextField();
+        name.getStyleClass().add("input");
         gridPane.add(name, 1, 0);
+
+        Tooltip nameErrorTooltip = new Tooltip(tr("Please specify a name!"));
 
         // category
         Label categoryLabel = new Label(tr("Category:"));
@@ -84,7 +86,10 @@ final class CreateShortcutPanel extends DetailsView {
         gridPane.add(categoryLabel, 0, 1);
 
         TextField category = new TextField();
+        category.getStyleClass().add("input");
         gridPane.add(category, 1, 1);
+
+        Tooltip categoryErrorTooltip = new Tooltip(tr("Please specify a category!"));
 
         // description
         Label descriptionLabel = new Label(tr("Description:"));
@@ -93,6 +98,7 @@ final class CreateShortcutPanel extends DetailsView {
         gridPane.add(descriptionLabel, 0, 2);
 
         TextArea description = new TextArea();
+        description.getStyleClass().add("input");
         gridPane.add(description, 1, 2);
 
         // miniature
@@ -102,6 +108,7 @@ final class CreateShortcutPanel extends DetailsView {
         gridPane.add(miniatureLabel, 0, 3);
 
         TextField miniature = new TextField();
+        miniature.getStyleClass().add("input");
 
         Button openMiniatureBrowser = new Button(tr("Choose"));
         openMiniatureBrowser.setOnAction(event -> {
@@ -116,6 +123,8 @@ final class CreateShortcutPanel extends DetailsView {
         HBox.setHgrow(miniature, Priority.ALWAYS);
         gridPane.add(miniatureHbox, 1, 3);
 
+        Tooltip miniatureErrorTooltip = new Tooltip(tr("Please specify a valid miniature!"));
+
         // executable
         Label executableLabel = new Label(tr("Executable:"));
         executableLabel.getStyleClass().add(CAPTION_TITLE_CSS_CLASS);
@@ -123,6 +132,7 @@ final class CreateShortcutPanel extends DetailsView {
         gridPane.add(executableLabel, 0, 4);
 
         TextField executable = new TextField();
+        executable.getStyleClass().add("input");
 
         Button openExecutableBrowser = new Button(tr("Choose"));
         openExecutableBrowser.setOnAction(event -> {
@@ -136,8 +146,7 @@ final class CreateShortcutPanel extends DetailsView {
         HBox.setHgrow(executable, Priority.ALWAYS);
         gridPane.add(executableHbox, 1, 4);
 
-        Label errorLabel = new Label();
-        errorLabel.setVisible(false);
+        Tooltip executableErrorTooltip = new Tooltip(tr("Please specify a valid executable!"));
 
         Region spacer = new Region();
         spacer.getStyleClass().add("detailsButtonSpacer");
@@ -145,13 +154,14 @@ final class CreateShortcutPanel extends DetailsView {
         Button createButton = new Button(tr("Create"));
         createButton.setOnMouseClicked(event -> {
             boolean error = false;
-            StringBuilder errorTextBuilder = new StringBuilder(tr("Cannot create new shortcut."));
             if (StringUtils.isEmpty(name.getText())) {
-                errorTextBuilder.append("\n" + tr("Please specify a name!"));
+                name.pseudoClassStateChanged(errorClass, true);
+                name.setTooltip(nameErrorTooltip);
                 error = true;
             }
             if (StringUtils.isEmpty(category.getText())) {
-                errorTextBuilder.append("\n" + tr("Please specify a category!"));
+                category.pseudoClassStateChanged(errorClass, true);
+                category.setTooltip(nameErrorTooltip);
                 error = true;
             }
             URI miniatureUri = null;
@@ -162,13 +172,15 @@ final class CreateShortcutPanel extends DetailsView {
                 if (miniatureFile.exists()) {
                     miniatureUri = miniatureFile.toURI();
                 } else {
-                    errorTextBuilder.append("\n" + tr("Please specify a valid miniature!"));
+                    miniature.pseudoClassStateChanged(errorClass, true);
+                    miniature.setTooltip(nameErrorTooltip);
                     error = true;
                 }
             }
             File executableFile = new File(executable.getText());
             if (!executableFile.exists()) {
-                errorTextBuilder.append("\n" + tr("Please specify a valid executable!"));
+                executable.pseudoClassStateChanged(errorClass, true);
+                executable.setTooltip(nameErrorTooltip);
                 error = true;
             }
             if (!error) {
@@ -176,13 +188,10 @@ final class CreateShortcutPanel extends DetailsView {
                         .withCategory(category.getText()).withDescription(description.getText())
                         .withMiniature(miniatureUri).withExecutable(executableFile).build();
                 this.onCreateShortcut.accept(newShortcut);
-            } else {
-                errorLabel.setText(errorTextBuilder.toString());
-                errorLabel.setVisible(true);
             }
         });
 
-        vBox.getChildren().addAll(gridPane, errorLabel, spacer, createButton);
+        vBox.getChildren().addAll(gridPane, spacer, createButton);
 
         this.setCenter(vBox);
     }

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/library/EditShortcutPanel.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/library/EditShortcutPanel.java
@@ -57,7 +57,7 @@ final class EditShortcutPanel extends DetailsView {
     private GridPane gridPane;
     private Button saveButton;
 
-    // consumer called when a shortcut should changed
+    // consumer called when a shortcut changed
     private Consumer<ShortcutDTO> onShortcutChanged;
 
     /**

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/library/LibrarySidebar.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/library/LibrarySidebar.java
@@ -66,8 +66,7 @@ public class LibrarySidebar extends LeftSidebar {
     private Consumer<ShortcutCategoryDTO> onCategorySelection;
 
     // consumers called when a script should be run or a console be opened
-    private Consumer<File> onShortcutCreate = executable -> {
-    };
+    private Runnable onCreateShortcut;
     private Consumer<File> onScriptRun;
     private Runnable onOpenConsole;
 
@@ -180,17 +179,7 @@ public class LibrarySidebar extends LeftSidebar {
     private void populateAdvancedTools() {
         LeftButton createShortcut = new LeftButton(tr("Create shortcut"));
         createShortcut.getStyleClass().add("openTerminal");
-        createShortcut.setOnMouseClicked(event -> {
-            final FileChooser fileChooser = new FileChooser();
-            fileChooser.setTitle(tr("Open a script"));
-
-            // TODO: use correct owner window
-            final File executable = fileChooser.showOpenDialog(null);
-
-            if (executable != null) {
-                this.onShortcutCreate.accept(executable);
-            }
-        });
+        createShortcut.setOnMouseClicked(event -> onCreateShortcut.run());
 
         this.runScript = new LeftButton(tr("Run a script"));
         this.runScript.getStyleClass().add("scriptButton");
@@ -241,12 +230,12 @@ public class LibrarySidebar extends LeftSidebar {
     }
 
     /**
-     * This method updates the consumer, that is called when the "Create shortcut" button in the advanced tools section has been clicked.
+     * This method updates the runnable, that is called when the "Create shortcut" button in the advanced tools section has been clicked.
      *
-     * @param onShortcutCreate The new consumer to be called
+     * @param onCreateShortcut The new runnable to be called
      */
-    public void setOnShortcutCreate(Consumer<File> onShortcutCreate) {
-        this.onShortcutCreate = onShortcutCreate;
+    public void setOnCreateShortcut(Runnable onCreateShortcut) {
+        this.onCreateShortcut = onCreateShortcut;
     }
 
     /**

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/library/ViewLibrary.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/library/ViewLibrary.java
@@ -37,6 +37,7 @@ import org.phoenicis.javafx.views.common.widgets.lists.ListWidgetEntry;
 import org.phoenicis.javafx.views.mainwindow.MainWindowView;
 import org.phoenicis.javafx.views.mainwindow.SimpleFilter;
 import org.phoenicis.library.dto.ShortcutCategoryDTO;
+import org.phoenicis.library.dto.ShortcutCreationDTO;
 import org.phoenicis.library.dto.ShortcutDTO;
 
 import java.io.File;
@@ -51,6 +52,7 @@ public class ViewLibrary extends MainWindowView<LibrarySidebar> {
     private final ObjectMapper objectMapper;
 
     private LibraryPanel libraryPanel;
+    private CreateShortcutPanel createShortcutPanel;
     private EditShortcutPanel editShortcutPanel;
     private final Tab installedApplicationsTab;
 
@@ -136,6 +138,7 @@ public class ViewLibrary extends MainWindowView<LibrarySidebar> {
             filter.clearFilters();
             this.closeDetailsView();
         });
+        this.sidebar.setOnCreateShortcut(this::showShortcutCreate);
 
         this.setSidebar(this.sidebar);
 
@@ -153,6 +156,7 @@ public class ViewLibrary extends MainWindowView<LibrarySidebar> {
         this.setCenter(this.libraryTabs);
 
         this.libraryPanel = new LibraryPanel(objectMapper);
+        this.createShortcutPanel = new CreateShortcutPanel();
         this.editShortcutPanel = new EditShortcutPanel(objectMapper);
     }
 
@@ -192,6 +196,17 @@ public class ViewLibrary extends MainWindowView<LibrarySidebar> {
     }
 
     /**
+     * shows a details view which allows to create a new shortcut
+     */
+    private void showShortcutCreate() {
+        this.createShortcutPanel.setOnClose(this::closeDetailsView);
+        this.createShortcutPanel.setMaxWidth(600);
+        this.createShortcutPanel.prefWidthProperty().bind(this.getTabPane().widthProperty().divide(3));
+        this.createShortcutPanel.populate();
+        this.showDetailsView(this.createShortcutPanel);
+    }
+
+    /**
      * shows a details view which allows to edit the given shortcut
      * @param shortcutDTO
      */
@@ -221,8 +236,8 @@ public class ViewLibrary extends MainWindowView<LibrarySidebar> {
         this.sidebar.setOnOpenConsole(onOpenConsole);
     }
 
-    public void setOnShortcutCreate(Consumer<File> onShortcutCreate) {
-        this.sidebar.setOnShortcutCreate(onShortcutCreate);
+    public void setOnShortcutCreate(Consumer<ShortcutCreationDTO> onShortcutCreate) {
+        this.createShortcutPanel.setOnCreateShortcut(onShortcutCreate);
     }
 
     public void setOnShortcutUninstall(Consumer<ShortcutDTO> onShortcutUninstall) {

--- a/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/default/main.less
+++ b/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/default/main.less
@@ -602,6 +602,10 @@
   -fx-font-family: "Roboto Light";
 }
 
+.input:error {
+  -fx-background-color: #f31111;
+}
+
 .buttonWithIcon {
   -fx-background-color: transparent;
   -fx-label-padding: 0.2em 0 0.2em 2.2em;

--- a/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/default/main.less
+++ b/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/default/main.less
@@ -25,6 +25,10 @@
 /*******************************************************/
 .text-field {
   -fx-background-radius: 1em;
+
+  &:error {
+    -fx-text-box-border: #f31111;
+  }
 }
 
 /*******************************************************/
@@ -600,10 +604,6 @@
 
 .normalLabel {
   -fx-font-family: "Roboto Light";
-}
-
-.input:error {
-  -fx-background-color: #f31111;
 }
 
 .buttonWithIcon {

--- a/phoenicis-library/src/main/java/org/phoenicis/library/dto/ShortcutCreationDTO.java
+++ b/phoenicis-library/src/main/java/org/phoenicis/library/dto/ShortcutCreationDTO.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2015-2017 PÂRIS Quentin
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package org.phoenicis.library.dto;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+
+import java.io.File;
+import java.net.URI;
+import java.util.Comparator;
+
+@JsonDeserialize(builder = ShortcutCreationDTO.Builder.class)
+public class ShortcutCreationDTO {
+    private final String name;
+    private final String category;
+    private final String description;
+    private final URI icon;
+    private final URI miniature;
+    private final File executable;
+
+    private ShortcutCreationDTO(Builder builder) {
+        name = builder.name;
+        category = builder.category;
+        description = builder.description;
+        icon = builder.icon;
+        miniature = builder.miniature;
+        executable = builder.executable;
+    }
+
+    public URI getIcon() {
+        return icon;
+    }
+
+    public URI getMiniature() {
+        return miniature;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public File getExecutable() {
+        return executable;
+    }
+
+    public static Comparator<ShortcutCreationDTO> nameComparator() {
+        return (o1, o2) -> o1.getName().compareToIgnoreCase(o2.getName());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ShortcutCreationDTO that = (ShortcutCreationDTO) o;
+
+        return new EqualsBuilder()
+                .append(name, that.name)
+                .append(category, that.category)
+                .append(description, that.description)
+                .append(icon, that.icon)
+                .append(miniature, that.miniature)
+                .append(executable, that.executable)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 37)
+                .append(name)
+                .append(category)
+                .append(description)
+                .append(icon)
+                .append(miniature)
+                .append(executable)
+                .toHashCode();
+    }
+
+    @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "with")
+    public static class Builder {
+        private String name;
+        private String category;
+        private String description;
+        private URI icon;
+        private URI miniature;
+        private File executable;
+
+        public Builder() {
+            // Default constructor
+        }
+
+        public Builder(ShortcutCreationDTO shortcutDTO) {
+            this.name = shortcutDTO.name;
+            this.category = shortcutDTO.category;
+            this.description = shortcutDTO.description;
+            this.icon = shortcutDTO.icon;
+            this.miniature = shortcutDTO.miniature;
+            this.executable = shortcutDTO.executable;
+        }
+
+        public Builder withName(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder withCategory(String category) {
+            this.category = category;
+            return this;
+        }
+
+        public Builder withDescription(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public Builder withIcon(URI icon) {
+            this.icon = icon;
+            return this;
+        }
+
+        public Builder withMiniature(URI miniature) {
+            this.miniature = miniature;
+            return this;
+        }
+
+        public Builder withExecutable(File executable) {
+            this.executable = executable;
+            return this;
+        }
+
+        public ShortcutCreationDTO build() {
+            return new ShortcutCreationDTO(this);
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+
+}


### PR DESCRIPTION
requires PhoenicisOrg/Scripts#376

When you click "Create shortcut" in the library sidebar, a new details view opens:
![details](https://user-images.githubusercontent.com/3973260/29768157-7f676ed2-8be5-11e7-9e6f-bcaf5cb2dde9.png)

If you do not fill the form properly, it marks the wrong fields and shows an error message in a tooltip:
![error](https://user-images.githubusercontent.com/3973260/29770685-83aa13ea-8bf0-11e7-8bd2-2eabe8fbbfff.png)


fixes #1060 