### PR TITLE
Improve the performance of PhoenicisFilteredList

### DIFF
--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/common/lists/AdhocList.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/common/lists/AdhocList.java
@@ -60,7 +60,7 @@ public class AdhocList<E> extends PhoenicisTransformationList<E, E> {
                 perm[i + others.length] = c.getPermutation(i) + others.length;
             }
 
-            nextPermutation(from, to, perm);
+            nextPermutation(others.length + from, others.length + to, perm);
         }
     }
 

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/common/lists/ExpandedList.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/common/lists/ExpandedList.java
@@ -95,6 +95,9 @@ public class ExpandedList<E, F> extends PhoenicisTransformationList<E, F> {
         int from = c.getFrom();
         int to = c.getTo();
 
+        int expandedFrom = getFirstIndex(from);
+        int expandedTo = getLastIndexPlusOne(to - 1);
+
         if (to > from) {
             List<? extends E> beforePermutation = expandedValues.stream().flatMap(List::stream)
                     .collect(Collectors.toList());
@@ -118,7 +121,7 @@ public class ExpandedList<E, F> extends PhoenicisTransformationList<E, F> {
 
             int[] perm = beforePermutation.stream().mapToInt(afterPermutation::indexOf).toArray();
 
-            nextPermutation(from, to, perm);
+            nextPermutation(expandedFrom, expandedTo, perm);
         }
     }
 


### PR DESCRIPTION
Fixes #1076. The `trigger` method is now based on the `update` method in `FilteredList`, with the only changes that it checks the whole list for updates and doesn't call `nextUpdate` if the value fulfilled the filter condition before and after the check.

In addition I've fixed the permutation range in some `permute` methods.