### PR TITLE
define Wine tools in JS

### DIFF
--- a/phoenicis-containers/src/main/java/org/phoenicis/containers/wine/WinePrefixContainerController.java
+++ b/phoenicis-containers/src/main/java/org/phoenicis/containers/wine/WinePrefixContainerController.java
@@ -125,6 +125,25 @@ public class WinePrefixContainerController {
                 }, errorCallback), errorCallback);
     }
 
+    /**
+     * runs a tool in a given prefix
+     * @param winePrefix
+     * @param toolName
+     * @param doneCallback
+     * @param errorCallback
+     */
+    public void runTool(WinePrefixContainerDTO winePrefix, String toolName, Runnable doneCallback,
+            Consumer<Exception> errorCallback) {
+        final InteractiveScriptSession interactiveScriptSession = scriptInterpreter.createInteractiveSession();
+
+        interactiveScriptSession.eval("include([\"Engines\", \"Wine\", \"Tools\", \"" + toolName + "\"]);",
+                ignored -> interactiveScriptSession.eval("new " + toolName + "()", output -> {
+                    final ScriptObjectMirror toolObject = (ScriptObjectMirror) output;
+                    toolObject.callMember("run", winePrefix.getName());
+                    doneCallback.run();
+                }, errorCallback), errorCallback);
+    }
+
     public void deletePrefix(WinePrefixContainerDTO winePrefix, Consumer<Exception> errorCallback) {
         try {
             fileUtilities.remove(new File(winePrefix.getPath()));

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/containers/WinePrefixContainerWineToolsTab.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/containers/WinePrefixContainerWineToolsTab.java
@@ -58,7 +58,7 @@ public class WinePrefixContainerWineToolsTab extends Tab {
         configureWine.getStyleClass().addAll("wineToolButton", "configureWine");
         configureWine.setOnMouseClicked(event -> {
             this.lockAll();
-            winePrefixContainerController.runInPrefix(container, "winecfg", this::unlockAll,
+            winePrefixContainerController.runTool(container, "ConfigureWine", this::unlockAll,
                     e -> Platform.runLater(() -> new ErrorMessage("Error", e).show()));
         });
 
@@ -66,7 +66,7 @@ public class WinePrefixContainerWineToolsTab extends Tab {
         registryEditor.getStyleClass().addAll("wineToolButton", "registryEditor");
         registryEditor.setOnMouseClicked(event -> {
             this.lockAll();
-            winePrefixContainerController.runInPrefix(container, "regedit", this::unlockAll,
+            winePrefixContainerController.runTool(container, "WineRegistryEditor", this::unlockAll,
                     e -> Platform.runLater(() -> new ErrorMessage("Error", e).show()));
         });
 
@@ -74,7 +74,7 @@ public class WinePrefixContainerWineToolsTab extends Tab {
         rebootWindows.getStyleClass().addAll("wineToolButton", "rebootWindows");
         rebootWindows.setOnMouseClicked(event -> {
             this.lockAll();
-            winePrefixContainerController.runInPrefix(container, "wineboot", this::unlockAll,
+            winePrefixContainerController.runInPrefix(container, "RebootWine", this::unlockAll,
                     e -> Platform.runLater(() -> new ErrorMessage("Error", e).show()));
         });
 
@@ -90,7 +90,7 @@ public class WinePrefixContainerWineToolsTab extends Tab {
         commandPrompt.getStyleClass().addAll("wineToolButton", "commandPrompt");
         commandPrompt.setOnMouseClicked(event -> {
             this.lockAll();
-            winePrefixContainerController.runInPrefix(container, "wineconsole", this::unlockAll,
+            winePrefixContainerController.runTool(container, "WineConsole", this::unlockAll,
                     e -> Platform.runLater(() -> new ErrorMessage("Error", e).show()));
         });
 
@@ -98,7 +98,7 @@ public class WinePrefixContainerWineToolsTab extends Tab {
         taskManager.getStyleClass().addAll("wineToolButton", "taskManager");
         taskManager.setOnMouseClicked(event -> {
             this.lockAll();
-            winePrefixContainerController.runInPrefix(container, "taskmgr", this::unlockAll,
+            winePrefixContainerController.runTool(container, "WineTaskManager", this::unlockAll,
                     e -> Platform.runLater(() -> new ErrorMessage("Error", e).show()));
         });
 
@@ -114,7 +114,7 @@ public class WinePrefixContainerWineToolsTab extends Tab {
         uninstallWine.getStyleClass().addAll("wineToolButton", "uninstallWine");
         uninstallWine.setOnMouseClicked(event -> {
             this.lockAll();
-            winePrefixContainerController.runInPrefix(container, "uninstaller", this::unlockAll,
+            winePrefixContainerController.runTool(container, "WineUninstaller", this::unlockAll,
                     e -> Platform.runLater(() -> new ErrorMessage("Error", e).show()));
         });
 


### PR DESCRIPTION
requires PhoenicisOrg/Scripts#391

This approach allows us to define the engine specific tools directly in JS. We can use it later to implement a generic engine tools tab in the "Containers" view.
