### PR TITLE
removed "create shortcut" from "Containers" tab

### DIFF
--- a/phoenicis-containers/src/main/java/org/phoenicis/containers/wine/WinePrefixContainerController.java
+++ b/phoenicis-containers/src/main/java/org/phoenicis/containers/wine/WinePrefixContainerController.java
@@ -150,29 +150,6 @@ public class WinePrefixContainerController {
                 });
     }
 
-    /**
-     * creates a shortcut for a given executable in a Wine prefix
-     * @param winePrefix the Wine prefix
-     * @param name name which is shown in the library
-     * @param executable filename of the executable (WineShortcut will search for this file in the given prefix)
-     * @param doneCallback callback executed after the shortcut has been created
-     * @param errorCallback callback executed if there is an error
-     */
-    public void createShortcut(WinePrefixContainerDTO winePrefix, String name, String executable, Runnable doneCallback,
-            Consumer<Exception> errorCallback) {
-        final InteractiveScriptSession interactiveScriptSession = scriptInterpreter.createInteractiveSession();
-
-        interactiveScriptSession.eval("include([\"Engines\", \"Wine\", \"Shortcuts\", \"Wine\"]);",
-                ignored -> interactiveScriptSession.eval("new WineShortcut()", output -> {
-                    final ScriptObjectMirror wine = (ScriptObjectMirror) output;
-                    wine.callMember("name", name);
-                    wine.callMember("search", executable);
-                    wine.callMember("prefix", winePrefix.getName());
-                    wine.callMember("create");
-                    doneCallback.run();
-                }, errorCallback), errorCallback);
-    }
-
     public void openTerminalInPrefix(WinePrefixContainerDTO winePrefixContainerDTO) {
         final Map<String, String> environment = new HashMap<>();
         environment.put("WINEPREFIX", winePrefixContainerDTO.getPath());

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/containers/WinePrefixContainerToolsTab.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/containers/WinePrefixContainerToolsTab.java
@@ -67,24 +67,6 @@ public class WinePrefixContainerToolsTab extends Tab {
 
         toolsContentPane.getChildren().add(openTerminal);
 
-        Button createShortcut = new Button(tr("Create shortcut"));
-        createShortcut.getStyleClass().addAll("toolButton", "openTerminal");
-        createShortcut.setOnMouseClicked(event -> {
-            this.lockAll();
-            FileChooser fileChooser = new FileChooser();
-            fileChooser.setTitle(tr("Choose executable"));
-            File file = fileChooser.showOpenDialog(this.getContent().getScene().getWindow());
-            if (file != null) {
-                winePrefixContainerController.createShortcut(container, file.getName(), file.getName(), this::unlockAll,
-                        e -> Platform.runLater(() -> new ErrorMessage("Error", e).show()));
-            }
-            this.unlockAll();
-        });
-
-        this.lockableElements.add(createShortcut);
-
-        toolsContentPane.getChildren().add(createShortcut);
-
         Button runExecutable = new Button(tr("Run executable"));
         runExecutable.getStyleClass().addAll("toolButton", "runExecutable");
         runExecutable.setOnMouseClicked(event -> {


### PR DESCRIPTION
We have it in "Library" now. There you can also edit the new shortcut directly.