### PR TITLE
fixed generic engines and engine tools

### DIFF
--- a/phoenicis-engines/src/main/java/org/phoenicis/engines/EngineToolsManager.java
+++ b/phoenicis-engines/src/main/java/org/phoenicis/engines/EngineToolsManager.java
@@ -80,7 +80,7 @@ public class EngineToolsManager {
         // get engine CategoryDTOs
         List<CategoryDTO> categoryDTOS = new ArrayList<>();
         for (TypeDTO typeDTO : repositoryDTO.getTypes()) {
-            if (typeDTO.getName().equals("Engines")) {
+            if (typeDTO.getId().equals("Engines")) {
                 categoryDTOS = typeDTO.getCategories();
             }
         }

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/containers/ContainersController.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/containers/ContainersController.java
@@ -90,7 +90,7 @@ public class ContainersController {
                     .flatMap(subCategory -> subCategory.getPackages().stream())
                     .collect(Collectors.toList()),*/
                     engineToolsManager,
-                    Optional.of(engineTools.get("Wine")),
+                    Optional.ofNullable(engineTools.get("Wine")),
                     winePrefixContainerController);
 
             panel.setOnDeletePrefix(winePrefixDTO -> {

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/containers/ContainersController.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/containers/ContainersController.java
@@ -90,7 +90,7 @@ public class ContainersController {
                     .flatMap(subCategory -> subCategory.getPackages().stream())
                     .collect(Collectors.toList()),*/
                     engineToolsManager,
-                    engineTools.get("Wine"),
+                    Optional.of(engineTools.get("Wine")),
                     winePrefixContainerController);
 
             panel.setOnDeletePrefix(winePrefixDTO -> {

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/engines/EnginesController.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/engines/EnginesController.java
@@ -92,7 +92,7 @@ public class EnginesController {
         Platform.runLater(() -> {
             List<CategoryDTO> categoryDTOS = new ArrayList<>();
             for (TypeDTO typeDTO : repositoryDTO.getTypes()) {
-                if (typeDTO.getName().equals("Engines")) {
+                if (typeDTO.getId().equals("Engines")) {
                     categoryDTOS = typeDTO.getCategories();
                 }
             }

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/containers/ContainerPanelFactory.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/containers/ContainerPanelFactory.java
@@ -26,6 +26,7 @@ import org.phoenicis.repository.dto.ApplicationDTO;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
+import java.util.Optional;
 
 public class ContainerPanelFactory<T extends AbstractContainerPanel<C>, C extends ContainerDTO> {
     private final Class<T> clazz;
@@ -39,11 +40,11 @@ public class ContainerPanelFactory<T extends AbstractContainerPanel<C>, C extend
     public T createContainerPanel(C containerDTO,
             List<EngineVersionDTO> engineVersions,
             EngineToolsManager engineToolsManager,
-            ApplicationDTO engineTools,
+            Optional<ApplicationDTO> engineTools,
             WinePrefixContainerController winePrefixContainerController) {
         try {
             return this.clazz
-                    .getConstructor(entityClazz, List.class, EngineToolsManager.class, ApplicationDTO.class,
+                    .getConstructor(entityClazz, List.class, EngineToolsManager.class, Optional.class,
                             WinePrefixContainerController.class)
                     .newInstance(containerDTO, engineVersions, engineToolsManager, engineTools,
                             winePrefixContainerController);

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/containers/WinePrefixContainerPanel.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/containers/WinePrefixContainerPanel.java
@@ -25,6 +25,7 @@ import org.phoenicis.engines.dto.EngineVersionDTO;
 import org.phoenicis.repository.dto.ApplicationDTO;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Consumer;
 
 public class WinePrefixContainerPanel extends AbstractContainerPanel<WinePrefixContainerDTO> {
@@ -37,19 +38,24 @@ public class WinePrefixContainerPanel extends AbstractContainerPanel<WinePrefixC
     public WinePrefixContainerPanel(WinePrefixContainerDTO containerEntity,
             List<EngineVersionDTO> engineVersions,
             EngineToolsManager engineToolsManager,
-            ApplicationDTO engineTools,
+            Optional<ApplicationDTO> engineTools,
             WinePrefixContainerController winePrefixContainerController) {
         super(containerEntity, engineVersions);
 
         this.informationTab = new WinePrefixContainerInformationTab(containerEntity, engineVersions);
+        this.tabPane.getTabs().add(this.informationTab);
         this.displayTab = new WinePrefixContainerDisplayTab(containerEntity, winePrefixContainerController);
+        this.tabPane.getTabs().add(this.displayTab);
         this.inputTab = new WinePrefixContainerInputTab(containerEntity);
-        this.wineToolsTab = new WinePrefixContainerWineToolsTab(containerEntity, winePrefixContainerController,
-                engineToolsManager, engineTools);
+        this.tabPane.getTabs().add(this.inputTab);
+        if (engineTools.isPresent()) {
+            this.wineToolsTab = new WinePrefixContainerWineToolsTab(containerEntity, winePrefixContainerController,
+                    engineToolsManager, engineTools.get());
+            this.tabPane.getTabs().add(this.wineToolsTab);
+        }
         this.toolsTab = new WinePrefixContainerToolsTab(containerEntity, winePrefixContainerController,
                 engineToolsManager);
-
-        this.tabPane.getTabs().setAll(informationTab, displayTab, inputTab, wineToolsTab, toolsTab);
+        this.tabPane.getTabs().add(this.toolsTab);
     }
 
     public void setOnDeletePrefix(Consumer<WinePrefixContainerDTO> onDeletePrefix) {

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/containers/WinePrefixContainerWineToolsTab.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/containers/WinePrefixContainerWineToolsTab.java
@@ -51,6 +51,10 @@ public class WinePrefixContainerWineToolsTab extends Tab {
         final VBox toolsPane = new VBox();
         final Text title = new TextWithStyle(tr("Wine tools"), TITLE_CSS_CLASS);
 
+        if (engineTools == null) {
+            return;
+        }
+
         toolsPane.getStyleClass().add(CONFIGURATION_PANE_CSS_CLASS);
         toolsPane.getChildren().add(title);
 

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/containers/WinePrefixContainerWineToolsTab.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/containers/WinePrefixContainerWineToolsTab.java
@@ -51,10 +51,6 @@ public class WinePrefixContainerWineToolsTab extends Tab {
         final VBox toolsPane = new VBox();
         final Text title = new TextWithStyle(tr("Wine tools"), TITLE_CSS_CLASS);
 
-        if (engineTools == null) {
-            return;
-        }
-
         toolsPane.getStyleClass().add(CONFIGURATION_PANE_CSS_CLASS);
         toolsPane.getChildren().add(title);
 


### PR DESCRIPTION
Fixes the problem that engine tools and engines could not be loaded if "Engines" was translated. Also: if no engine tools are available, the "Engine tools" tab in the container view is not shown.

fixes #1122