### PR TITLE
fixed baseName in updateShortcut()

### DIFF
--- a/phoenicis-library/src/main/java/org/phoenicis/library/ShortcutManager.java
+++ b/phoenicis-library/src/main/java/org/phoenicis/library/ShortcutManager.java
@@ -157,7 +157,7 @@ public class ShortcutManager {
     }
 
     public void updateShortcut(ShortcutDTO shortcutDTO) {
-        final String baseName = shortcutDTO.getInfo().getName();
+        final String baseName = shortcutDTO.getId();
         final File shortcutDirectory = new File(this.shortcutDirectory);
 
         // backup icon if it didn't change (deleteShortcut will delete it -> icon lost after shortcut update)


### PR DESCRIPTION
As e.g. the shortcut miniature file for 7-zip is called "7zip.miniature", the miniature was lost when editing the shortcut.