### PR TITLE
set default value if tools.linux-terminal does not exist

### DIFF
--- a/phoenicis-settings/src/main/java/org/phoenicis/settings/Setting.java
+++ b/phoenicis-settings/src/main/java/org/phoenicis/settings/Setting.java
@@ -19,7 +19,7 @@
 package org.phoenicis.settings;
 
 public enum Setting {
-    TERMINAL("tools.linux-terminal");
+    TERMINAL("${tools.linux-terminal:}");
 
     private final String propertyName;
 

--- a/phoenicis-settings/src/main/java/org/phoenicis/settings/SettingsManager.java
+++ b/phoenicis-settings/src/main/java/org/phoenicis/settings/SettingsManager.java
@@ -32,7 +32,7 @@ import java.io.OutputStream;
 import java.util.List;
 
 public class SettingsManager {
-    @Value("${tools.linux-terminal}")
+    @Value("${tools.linux-terminal:}")
     private String terminal;
 
     @Autowired

--- a/phoenicis-tools/src/main/java/org/phoenicis/tools/system/SystemConfiguration.java
+++ b/phoenicis-tools/src/main/java/org/phoenicis/tools/system/SystemConfiguration.java
@@ -29,7 +29,7 @@ import java.util.Optional;
 
 @Configuration
 public class SystemConfiguration {
-    @Value("${tools.linux-terminal}")
+    @Value("${tools.linux-terminal:}")
     private String linuxTerminalCommand;
 
     @Bean


### PR DESCRIPTION
For example on Mac OS, `tools.linux-terminal` does not exist (also not required). Use an empty String as default in these cases.

fixes #1139