### PR TITLE
add travisci build status badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Phoenicis PlayOnLinux and PlayOnMac 5
 This is the Phoenicis PlayOnLinux and PlayOnMac 5 repository.
 
+[![Build Status](https://travis-ci.org/PhoenicisOrg/POL-POM-5.svg?branch=master)](https://travis-ci.org/PhoenicisOrg/POL-POM-5)
+------------
+
 ## Community
 * Forums : http://www.playonlinux.com/en/forums.html
 * Slack : https://join.slack.com/phoenicis-org/shared_invite/MTkzMTMwMjM3MjcxLTE0OTY1MTQzNzktY2IzOTE2NmE3NA


### PR DESCRIPTION
Just a simple one, poking around POL and saw you guys run TravisCI so you may as well broadcast your build status. I always find it helps me determine the health of an OS project. I would have added the Codacy badge as well but it appears you have to have access to the profile itself, which I do not. Context:
https://support.codacy.com/hc/en-us/articles/212799365-Badges

Cheers.