### PR TITLE
Travis: avoid double builds on pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: java
 sudo: false
 
+# avoid double builds on pull requests
+branches:
+  only:
+    master
+
 addons:
   apt:
     packages:


### PR DESCRIPTION
If a branch from this repository (not a fork) shall be merged, Travis would execute the checks twice (see e.g. the PRs from dependabot).